### PR TITLE
Add support for Snapdragon S9, S9+, and N9

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -179,7 +179,8 @@ print_justified "G97[035][FN0], G977[BN], N97[05][FN0],"
 print_justified "N971N, N976[BN0], A[1245]05[FN], A105M,,"
 print_justified "A[25]05G, A[1245]05[FN], A105M, A[25]05G,"
 print_justified "A[25]05[YG]N, A405FM, T51[05], T72[05],"
-print_justified "T86[05], F900[FN] and F907[BN]."
+print_justified "T86[05], F900[FN], F907[BN],"
+print_justified "G96[50][00], N9600."
 print_justified "by Ian Macdonald"
 print_full_bar
 ui_print " "
@@ -197,7 +198,7 @@ fw=${bl:$((${#bl} - 4)):4}
 #
 device=${bl:0:$((${#bl} - 8))}
 
-if echo $device | grep -Ev 'G97([035][FN0]|7[BN])|N97([05][FN0]|6[BN0]|1N)|A([1245]05[FN]|105M|[25]05([YG]N|G)|405FM)|T(51|72|86)[05]|F90(0[FN]|7[BN])' >/dev/null; then
+if echo $device | grep -Ev 'G97([035][FN0]|7[BN])|N97([05][FN0]|6[BN0]|1N)|A([1245]05[FN]|105M|[25]05([YG]N|G)|405FM)|T(51|72|86)[05]|F90(0[FN]|7[BN])|G96[50][00]|N9600' >/dev/null; then
   ui_print " - Unsupported device detected. Installation aborted."
   ui_print " "
   exit 1


### PR DESCRIPTION
This is now applicable for G9600, G9650, and N9600 with the Android 10 update.